### PR TITLE
Imprv/enable to access only http

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/wordpress:4-master
+FROM bitnami/wordpress:4.8.3-r0
 
 # Add new scripts and configs to use sub directory.
 COPY ./scripts/app-entrypoint.sh /app-entrypoint.sh

--- a/configs/wordpress-vhost.conf
+++ b/configs/wordpress-vhost.conf
@@ -3,6 +3,7 @@ AddType application/x-httpd-php .php
 <VirtualHost  127.0.0.1:80  _default_:80>
   ServerAlias *
 
+  DocumentRoot /opt/bitnami/wordpress
   <Directory "/opt/bitnami/wordpress/wp">
   
     Options -Indexes +FollowSymLinks -MultiViews

--- a/scripts/app-entrypoint.sh
+++ b/scripts/app-entrypoint.sh
@@ -20,9 +20,6 @@ fi
 cp /configs/wordpress-vhost.conf /opt/bitnami/apache/conf/vhosts/wordpress-vhost.conf
 TLSCONFIG=$(sed -e ':loop;N;$!b loop;s/\n/\\n/g;s/&/\\&/g' <<'EOS'
 /** enable TLS forced in reverse proxy environment */
-// FORCE TLS ADMIN
-define('FORCE_SSL_ADMIN', true);
-
 // Avoid TLS loop
 //   cf. https://qiita.com/hirror/items/bb96e236c3ffc41e890e#%E3%83%AA%E3%83%90%E3%83%BC%E3%82%B9%E3%83%97%E3%83%AD%E3%82%AD%E3%82%B7%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E5%A0%B4%E5%90%88%E3%81%AEssl%E9%80%9A%E4%BF%A1 
 if ( ! empty( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' ) {


### PR DESCRIPTION
- Changed to enable to access only HTTP.
- Use bitnami/wordpress version 4.8.3-r0

