### PR TITLE
fix/2771-disabled-redirection-in-case-of-using-admin's-page

### DIFF
--- a/scripts/app-entrypoint.sh
+++ b/scripts/app-entrypoint.sh
@@ -31,12 +31,15 @@ cp /configs/wordpress-https-vhost.conf $APACHE_CONF_DIR
 # Replace wordpress config to enable sub directory
 if [ ! -f '/bitnami/wordpress/.subdirized' ]; then
   TLSCONFIG=$(sed -e ':loop;N;$!b loop;s/\n/\\n/g;s/&/\\&/g' <<'EOS'
-/** enable TLS forced in reverse proxy environment */
+/* Enable TLS forced in reverse proxy environment */
 // Avoid TLS loop
 //   cf. https://qiita.com/hirror/items/bb96e236c3ffc41e890e#%E3%83%AA%E3%83%90%E3%83%BC%E3%82%B9%E3%83%97%E3%83%AD%E3%82%AD%E3%82%B7%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E5%A0%B4%E5%90%88%E3%81%AEssl%E9%80%9A%E4%BF%A1 
 if ( ! empty( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' ) {
        $_SERVER['HTTPS']='on';
 }
+
+/* Disable redirection in case of using admin's page. */
+define('FORCE_SSL_ADMIN', false);
 
 EOS
 )


### PR DESCRIPTION
refs BVL-2771 ログイン画面・管理操作画面へアクセスしてもhttpsへリダイレクトしないようにする